### PR TITLE
fix: get default value for request method and key for request data

### DIFF
--- a/lib/rave.base.js
+++ b/lib/rave.base.js
@@ -47,8 +47,8 @@ var RaveBase = function (public_key, secret_key, base_url_or_production_flag) {
 	this.request = function (path, payload, callback) {
 
 		var requestOptions = {};
-		var requestMethod = RaveUtils.initDefaultValue(payload.method, 'POST' || 'PUT');
-		var datakey = requestMethod == 'POST' || 'PUT' ? 'body' : 'qs';
+		var requestMethod = RaveUtils.initDefaultValue(payload.method, 'POST');
+		var datakey = (requestMethod === 'POST' || requestMethod === 'PUT') ? 'body' : 'qs';
 		var requestJSON = datakey == 'body' ? true : false;
 		// console.log(payload)
 		requestOptions.uri = path;


### PR DESCRIPTION
In javascript, the term  'POST' || 'PUT' resolves to 'POST'
so when it is used in line 50 as var requestMethod = RaveUtils.initDefaultValue(payload.method, 'POST' || 'PUT'), it resolves the default request method to POST if no method is specified.

An issue arises in line 51, requestMethod === 'POST' || 'PUT' always resolves to the value 'PUT', so datakey is always 'body'. This causes an issue for requests that use a GET method and has params specified in it, because datakey is always set to body and never qs, and in javascript, GET requests ignore body object if specified. This is noticed in the request to fetch all transactions. The payload is supposed to be passed as a query parameters, and because datakey is set to body, it doesnt send it, so no filter passed to the request ever works