### PR TITLE
fix: excludeQuery for get balance by currency

### DIFF
--- a/services/misc/rave.balances-currency.js
+++ b/services/misc/rave.balances-currency.js
@@ -5,6 +5,7 @@ const { fetchBalance } = require('../schema/auxillary');
 async function service(data, _rave) {
   validator(fetchBalance, data);
   data.method = 'GET';
+  data.excludeQuery = true;
   const { body: response } = await _rave.request(
     `/v3/balances/${data.currency}`,
     data,


### PR DESCRIPTION
The currency param in getBalanceByCurrency endpoint is a path param and not a query string. 
The current implementation creates a query string like this `/v3/balances/NGNcurrency:NGN`  instead of `/v3/balances/NGN` so the endpoint always return "balance does not exist for this currency"