### PR TITLE
Updated the `getBalanceByCurrency` method to parse path parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 1.1.13 | 2024-11-19
+Updated the `getBalanceByCurrency` method to parse path parameters.
+
+### Version Changes
+- [FIXED] Update the `balance_currency` function in the Misc object to exclude queries when parsing a path parameter.
+
 ## 1.1.12 | 2024-09-27
 Updated the `account_bank` field in the list schema.
 

--- a/services/misc/rave.balances-currency.js
+++ b/services/misc/rave.balances-currency.js
@@ -5,6 +5,7 @@ const { fetchBalance } = require('../schema/auxillary');
 async function service(data, _rave) {
   validator(fetchBalance, data);
   data.method = 'GET';
+  data.excludeQuery = true;
   const { body: response } = await _rave.request(
     `/v3/balances/${data.currency}`,
     data,

--- a/test/rave.misc.test.js
+++ b/test/rave.misc.test.js
@@ -264,4 +264,39 @@ describe('#Rave Misc', function () {
     expect(resp.body.data).to.have.property('account_number');
     expect(resp.body.data).to.have.property('account_name');
   });
+
+  it('should fetch a balance by currency', async function () {
+    this.timeout(10000);
+
+    const fetchBalanceByCurrencySuccessStub = sinon
+      .stub(miscInstance, 'bal_currency')
+      .resolves({
+        body: {
+          status: 'success',
+          message: 'Wallet balance fetched',
+          data: {
+            currency: 'NGN',
+            available_balance: 4988877.82,
+            ledger_balance: 21072145.6
+          }
+        },
+      });
+
+    var payload = {
+      currency: 'NGN',
+    };
+
+    var resp = await miscInstance.bal_currency(payload);
+    // console.log(resp);
+
+    expect(fetchBalanceByCurrencySuccessStub).to.have.been.calledOnce;
+    expect(fetchBalanceByCurrencySuccessStub).to.have.been.calledOnceWith(payload);
+
+    expect(resp.body).to.have.property('status', 'success');
+    expect(resp.body).to.have.property('data');
+
+    expect(resp.body.data).to.have.property('currency');
+    expect(resp.body.data).to.have.property('available_balance');
+    expect(resp.body.data).to.have.property('ledger_balance');
+  });
 });


### PR DESCRIPTION
The `balance_currency` function in the Misc object was updated to exclude queries when parsing a path parameter.
